### PR TITLE
Add intraday trading simulator skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # StockINR
+
+This repository contains a simple proof-of-concept intraday trading simulator
+for the Indian stock market. The goal is to demonstrate how a large language
+ model (LLM) such as OpenAI's GPT series or Google's Gemini can be integrated
+ with a paper-trading workflow. The app can connect to a real broker if an API key is supplied or run
+in a dummy mode for evaluation.
+
+## Features
+
+- Dummy broker interface for paper trading with real-time prices
+- Optional real broker stub if `BROKER_API_KEY` is set
+- SQLite database to log all trades
+- LLM-driven decision engine to choose buy/sell/hold actions
+- Automated scheduler that runs during market hours
+- Command line app in `src/app.py`
+
+## Requirements
+
+- Python 3.10+
+- `openai` or `google-generativeai` depending on which LLM provider you use
+- `yfinance` and `schedule` packages
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Choose the LLM provider via the `LLM_PROVIDER` environment variable (`openai` or
+`gemini`) and set the corresponding API key (`OPENAI_API_KEY` or
+`GEMINI_API_KEY`). Optionally export `BROKER_API_KEY` to route trades to a real
+broker implementation. Then run:
+
+```bash
+python -m src.app
+```
+
+The application will run continuously, making LLM driven decisions every minute
+during Indian market hours. Trades are logged in `trades.db`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0.0
+google-generativeai>=0.1.0
+yfinance>=0.2.0
+schedule>=1.2.0

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,81 @@
+"""Simple intraday trading simulator using LLM decisions."""
+
+from dataclasses import dataclass
+from datetime import datetime, time as dtime, timezone, timedelta
+import time
+
+import schedule
+
+from broker import Broker, RealBroker
+from database import TradeDatabase
+from llm_decision import LLMDecisionMaker
+
+@dataclass
+class Config:
+    budget: float
+    llm_provider: str
+    llm_api_key: str
+    broker_api_key: str | None = None
+    interval: int = 60  # seconds between LLM decisions
+
+class TradingApp:
+    def __init__(self, config: Config):
+        self.config = config
+        self.db = TradeDatabase()
+        if config.broker_api_key:
+            self.broker = RealBroker(config.broker_api_key)
+        else:
+            self.broker = Broker()
+        self.broker.set_cash(config.budget)
+        self.llm = LLMDecisionMaker(config.llm_provider, config.llm_api_key)
+
+    def trading_step(self, context: str):
+        decisions = self.llm.decide(context, self.broker.cash)
+        for action, symbol in decisions:
+            price = self.broker.get_price(symbol)
+            try:
+                if action == "BUY":
+                    trade = self.broker.buy(symbol, 1, price)
+                    self.db.log_trade(trade)
+                elif action == "SELL":
+                    qty = self.broker.positions.get(symbol, 0)
+                    if qty > 0:
+                        trade = self.broker.sell(symbol, qty, price)
+                        self.db.log_trade(trade)
+                # HOLD does nothing
+            except ValueError as exc:
+                print(f"Could not execute {action} {symbol}: {exc}")
+
+    def is_market_open(self) -> bool:
+        tz = timezone(timedelta(hours=5, minutes=30))  # IST
+        now = datetime.now(tz).time()
+        return dtime(9, 15) <= now <= dtime(15, 30)
+
+    def start(self, context: str):
+        schedule.every(self.config.interval).seconds.do(self.trading_step, context)
+        while True:
+            if self.is_market_open():
+                schedule.run_pending()
+            time.sleep(1)
+
+def main():
+    import os
+    provider = os.environ.get("LLM_PROVIDER", "openai")
+    if provider.lower() == "gemini":
+        api_key = os.environ.get("GEMINI_API_KEY", "")
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        provider = "openai"
+    broker_key = os.environ.get("BROKER_API_KEY")
+    config = Config(
+        budget=10000.0,
+        llm_provider=provider,
+        llm_api_key=api_key,
+        broker_api_key=broker_key,
+    )
+    app = TradingApp(config)
+    context = "Historical data goes here"
+    app.start(context)
+
+if __name__ == "__main__":
+    main()

--- a/src/broker.py
+++ b/src/broker.py
@@ -1,0 +1,77 @@
+"""Broker interfaces used by the app."""
+
+
+class Broker:
+    """A dummy broker interface for paper trading.
+
+    It uses real-time prices where possible but does not place real orders.
+    """
+
+    def __init__(self):
+        self.cash = 0
+        self.positions = {}
+
+    def set_cash(self, amount: float):
+        self.cash = amount
+
+    def buy(self, symbol: str, quantity: int, price: float):
+        cost = quantity * price
+        if cost > self.cash:
+            raise ValueError("Insufficient cash to buy")
+        self.cash -= cost
+        self.positions[symbol] = self.positions.get(symbol, 0) + quantity
+        return {
+            "type": "buy",
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": price,
+        }
+
+    def sell(self, symbol: str, quantity: int, price: float):
+        if self.positions.get(symbol, 0) < quantity:
+            raise ValueError("Insufficient shares to sell")
+        self.positions[symbol] -= quantity
+        proceeds = quantity * price
+        self.cash += proceeds
+        return {
+            "type": "sell",
+            "symbol": symbol,
+            "quantity": quantity,
+            "price": price,
+        }
+
+    def get_price(self, symbol: str) -> float:
+        """Fetch the latest market price for a symbol using yfinance."""
+        try:
+            import yfinance as yf
+
+            ticker = yf.Ticker(symbol)
+            info = ticker.fast_info
+            return float(info.get("lastPrice") or info.get("regularMarketPrice"))
+        except Exception:
+            # Fall back to a dummy price if fetching fails
+            return 100.0
+
+
+class RealBroker(Broker):
+    """Placeholder for a real broker implementation.
+
+    In a production setup this would talk to the broker's REST API using the
+    provided API key. Here we simply reuse the dummy logic while signalling
+    that real trades would be executed.
+    """
+
+    def __init__(self, api_key: str):
+        super().__init__()
+        self.api_key = api_key
+
+    def buy(self, symbol: str, quantity: int, price: float):
+        # TODO: integrate with real broker API
+        print(f"[REAL] Buying {quantity} {symbol} @ {price}")
+        return super().buy(symbol, quantity, price)
+
+    def sell(self, symbol: str, quantity: int, price: float):
+        # TODO: integrate with real broker API
+        print(f"[REAL] Selling {quantity} {symbol} @ {price}")
+        return super().sell(symbol, quantity, price)
+

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,37 @@
+import sqlite3
+from typing import Any, Dict
+
+class TradeDatabase:
+    def __init__(self, path: str = "trades.db"):
+        self.conn = sqlite3.connect(path)
+        self._create_tables()
+
+    def _create_tables(self):
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                type TEXT,
+                symbol TEXT,
+                quantity INTEGER,
+                price REAL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def log_trade(self, trade: Dict[str, Any]):
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO trades(timestamp, type, symbol, quantity, price) "
+            "VALUES(datetime('now'), ?, ?, ?, ?)",
+            (
+                trade["type"],
+                trade["symbol"],
+                trade["quantity"],
+                trade["price"],
+            ),
+        )
+        self.conn.commit()

--- a/src/llm_decision.py
+++ b/src/llm_decision.py
@@ -1,0 +1,67 @@
+"""LLM-backed decision making using OpenAI or Gemini."""
+
+from typing import List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except ImportError:  # pragma: no cover
+    openai = None
+
+try:  # pragma: no cover - optional dependency
+    import google.generativeai as genai
+except ImportError:  # pragma: no cover
+    genai = None
+
+
+class LLMDecisionMaker:
+    """Query an LLM provider to obtain trading actions."""
+
+    def __init__(self, provider: str, api_key: str):
+        provider = provider.lower()
+        self.provider = provider
+        if provider == "openai":
+            if openai is None:
+                raise ImportError("openai package not installed")
+            openai.api_key = api_key
+        elif provider == "gemini":
+            if genai is None:
+                raise ImportError("google-generativeai package not installed")
+            genai.configure(api_key=api_key)
+            self._gemini_model = genai.GenerativeModel("gemini-pro")
+        else:
+            raise ValueError(f"Unknown LLM provider: {provider}")
+
+    def _parse_lines(self, text: str) -> List[Tuple[str, str]]:
+        decisions: List[Tuple[str, str]] = []
+        for line in text.splitlines():
+            parts = line.strip().split()
+            if len(parts) >= 2:
+                action = parts[0].upper()
+                symbol = parts[1].upper()
+                decisions.append((action, symbol))
+        return decisions
+
+    def decide(self, context: str, budget: float) -> List[Tuple[str, str]]:
+        """Ask the configured LLM for decisions."""
+
+        prompt = (
+            "You are a trading assistant for the Indian stock market. "
+            "Based on the following context decide whether to BUY, SELL or HOLD "
+            "stocks within a budget of INR %.2f. Respond with one action per line "
+            "in the format 'ACTION SYMBOL'.\n%s" % (budget, context)
+        )
+
+        if self.provider == "openai":
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = resp.choices[0].message.content
+        elif self.provider == "gemini":
+            resp = self._gemini_model.generate_content(prompt)
+            text = resp.text or ""
+        else:  # pragma: no cover - should not occur
+            raise RuntimeError("Invalid provider")
+
+        return self._parse_lines(text)
+


### PR DESCRIPTION
## Summary
- set up Python app skeleton
- add dummy broker, database and LLM modules
- create a simple trading simulation in `app.py`
- document usage in README
- support Gemini as an alternative LLM provider

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684127163720833282cd6337b1d6facf